### PR TITLE
feat: add in-memory state store implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,12 +191,22 @@ See [Observability Guide](docs/OBSERVABILITY.md) for Prometheus setup, Grafana d
 
 ## 📚 Documentation
 
-**User Documentation:**
-- [Getting Started](https://valeriouberti.github.io/rigatoni/getting-started) - Quick start guide and tutorials
+**Getting Started:**
+- [Getting Started Guide](https://valeriouberti.github.io/rigatoni/getting-started) - Quick start guide and tutorials
+- [Examples](examples/README.md) - Comprehensive examples guide with runnable code
+  - [Core Examples](rigatoni-core/examples/README.md) - Pipeline, metrics, change streams
+  - [Destination Examples](rigatoni-destinations/examples/README.md) - S3, compression, partitioning
+- [Local Development Guide](docs/guides/local-development.md) - Complete local setup with Docker Compose
+
+**Architecture & Design:**
 - [Architecture Guide](https://valeriouberti.github.io/rigatoni/architecture) - System design and concepts
 - [Observability Guide](docs/OBSERVABILITY.md) - Metrics, monitoring, and alerting
 - [API Reference](https://docs.rs/rigatoni) - Complete API documentation
+
+**Guides:**
 - [User Guides](https://valeriouberti.github.io/rigatoni/guides/) - Task-specific guides
+- [Redis Configuration](docs/guides/redis-configuration.md) - Production state store setup
+- [S3 Configuration](docs/guides/s3-configuration.md) - Data lake best practices
 
 **Developer Documentation:**
 - [Contributing Guide](CONTRIBUTING.md) - How to contribute

--- a/docker/README.md
+++ b/docker/README.md
@@ -69,6 +69,14 @@ docker compose --profile ui up -d
 - Fastest startup time
 - CI/CD pipelines
 
+**Note:** You can make this even more minimal by using the in-memory StateStore instead of Redis:
+```rust
+use rigatoni_stores::memory::MemoryStore;
+let store = MemoryStore::new();  // No Redis needed!
+```
+
+See the `simple_pipeline_memory` example for a Redis-free setup.
+
 **Start:**
 ```bash
 docker compose -f docker-compose.minimal.yml up -d

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,405 @@
+# Rigatoni Examples
+
+This directory serves as a guide to all examples across the Rigatoni workspace. Examples are organized by crate to follow Rust best practices and maintain clear dependency boundaries.
+
+## Quick Links
+
+- [Core Examples](#core-examples) - Pipeline orchestration, change streams, metrics
+- [Destination Examples](#destination-examples) - S3 configurations and features
+- [Getting Started](#getting-started) - Recommended examples for beginners
+
+---
+
+## Getting Started
+
+### 🚀 Start Here: Simplest Example
+
+**[simple_pipeline_memory.rs](../rigatoni-core/examples/simple_pipeline_memory.rs)** - Absolute minimum setup
+
+```bash
+# Just MongoDB required (no Redis, S3, Prometheus)
+docker run -d --name mongodb -p 27017:27017 mongo:7.0 --replSet rs0
+docker exec mongodb mongosh --eval "rs.initiate()"
+
+# Run the example
+cargo run -p rigatoni-core --example simple_pipeline_memory
+```
+
+**What you'll learn:**
+- Basic pipeline setup
+- In-memory state store (no external dependencies)
+- Console output destination
+- MongoDB change stream integration
+
+**Perfect for:** First-time users, quick experiments, understanding core concepts
+
+---
+
+### 📊 Full Stack Example
+
+**[metrics_prometheus.rs](../rigatoni-core/examples/metrics_prometheus.rs)** - Complete production-like setup
+
+```bash
+# Start all services
+cd docker && docker compose up -d
+
+# Run the example
+cargo run -p rigatoni-core --example metrics_prometheus --features metrics-export
+
+# Generate test data
+./docker/scripts/generate-test-data.sh
+```
+
+**What you'll learn:**
+- Redis state store for distributed deployments
+- S3 destination with LocalStack
+- Prometheus metrics integration
+- Grafana dashboards
+- Complete observability setup
+
+**Perfect for:** Production preparation, learning best practices, full feature exploration
+
+---
+
+## Core Examples
+
+Located in [`rigatoni-core/examples/`](../rigatoni-core/examples/)
+
+### 1. simple_pipeline_memory.rs
+
+**Difficulty:** ⭐ Beginner
+**Dependencies:** MongoDB only
+**Run time:** `cargo run -p rigatoni-core --example simple_pipeline_memory`
+
+The simplest possible Rigatoni setup. Perfect starting point for beginners.
+
+**Features:**
+- In-memory state store (no Redis)
+- Console destination (prints to terminal)
+- Minimal configuration
+- Real-time event visualization
+
+**Use when:**
+- Learning Rigatoni for the first time
+- Quick local experiments
+- Testing pipeline logic
+- No infrastructure setup desired
+
+**Related docs:**
+- [Local Development Guide - Minimal Setup](../docs/guides/local-development.md#minimal-setup-mongodb-only)
+- [In-Memory StateStore API](https://docs.rs/rigatoni-stores/latest/rigatoni_stores/memory/)
+
+---
+
+### 2. metrics_prometheus.rs
+
+**Difficulty:** ⭐⭐ Intermediate
+**Dependencies:** MongoDB, Redis, LocalStack, Prometheus, Grafana
+**Run time:** `cargo run -p rigatoni-core --example metrics_prometheus --features metrics-export`
+
+Complete production-like example with full observability stack.
+
+**Features:**
+- Redis state store for fault tolerance
+- S3 destination with LocalStack
+- Prometheus metrics export
+- Grafana dashboard integration
+- Graceful shutdown handling
+
+**Use when:**
+- Preparing for production deployment
+- Learning observability patterns
+- Testing distributed state management
+- Building monitoring dashboards
+
+**Related docs:**
+- [Local Development Guide](../docs/guides/local-development.md)
+- [Observability Guide](../docs/OBSERVABILITY.md)
+- [Redis Configuration](../docs/guides/redis-configuration.md)
+
+---
+
+### 3. change_stream_listener.rs
+
+**Difficulty:** ⭐⭐ Intermediate
+**Dependencies:** MongoDB
+**Run time:** `cargo run -p rigatoni-core --example change_stream_listener`
+
+Low-level change stream API examples demonstrating direct usage without the full pipeline.
+
+**Features:**
+- Basic change stream listener
+- Filtering change events
+- Resume token handling
+- Multi-collection watching
+
+**Use when:**
+- Understanding MongoDB change streams
+- Building custom integrations
+- Need lower-level control
+- Learning the underlying mechanisms
+
+**Related docs:**
+- [Architecture - Change Streams](../docs/architecture.md)
+- [ChangeStreamListener API](https://docs.rs/rigatoni-core/latest/rigatoni_core/stream/)
+
+---
+
+## Destination Examples
+
+Located in [`rigatoni-destinations/examples/`](../rigatoni-destinations/examples/)
+
+### 1. s3_basic.rs
+
+**Difficulty:** ⭐ Beginner
+**Dependencies:** AWS credentials or LocalStack
+**Run time:** `cargo run -p rigatoni-destinations --example s3_basic --features s3,json`
+
+Simplest S3 destination usage with JSON serialization.
+
+**Features:**
+- Basic S3 configuration
+- JSON serialization
+- No compression
+- Default partitioning
+
+**Use when:**
+- First time using S3 destination
+- Simple data lake setup
+- Learning S3 destination basics
+
+**Environment setup:**
+```bash
+export S3_BUCKET="your-bucket-name"
+export AWS_REGION="us-east-1"
+# AWS credentials via ~/.aws/credentials or environment
+```
+
+---
+
+### 2. s3_with_compression.rs
+
+**Difficulty:** ⭐⭐ Intermediate
+**Dependencies:** AWS credentials or LocalStack
+**Run time:** `cargo run -p rigatoni-destinations --example s3_with_compression --features s3,json,gzip`
+
+Demonstrates compression options for reducing storage costs and improving performance.
+
+**Features:**
+- Gzip compression
+- Zstandard compression
+- Compression trade-offs
+- Storage optimization
+
+**Use when:**
+- Optimizing storage costs
+- Improving upload performance
+- Large data volumes
+- Bandwidth constraints
+
+---
+
+### 3. s3_advanced.rs
+
+**Difficulty:** ⭐⭐⭐ Advanced
+**Dependencies:** AWS credentials or LocalStack
+**Run time:** `cargo run -p rigatoni-destinations --example s3_advanced --features s3,json,parquet,gzip,zstandard`
+
+Advanced S3 features including multiple formats, compression, and partitioning strategies.
+
+**Features:**
+- Multiple serialization formats (JSON, Parquet)
+- Different compression algorithms
+- Hive-style partitioning
+- Date-based partitioning
+- Custom key generation strategies
+
+**Use when:**
+- Building production data lakes
+- Analytics workloads
+- Need partitioning for performance
+- Working with data warehouses
+
+**Related docs:**
+- [S3 Configuration Guide](../docs/guides/s3-configuration.md)
+
+---
+
+## Running Examples by Use Case
+
+### Local Development / Learning
+
+```bash
+# Simplest setup - just MongoDB
+cargo run -p rigatoni-core --example simple_pipeline_memory
+```
+
+### Testing with S3
+
+```bash
+# Start LocalStack
+docker compose -f docker/docker-compose.localstack.yml up -d
+
+# Run S3 examples
+cargo run -p rigatoni-destinations --example s3_basic --features s3,json
+```
+
+### Full Production-Like Setup
+
+```bash
+# Start all services
+docker compose -f docker/docker-compose.yml up -d
+
+# Run full stack example
+cargo run -p rigatoni-core --example metrics_prometheus --features metrics-export
+```
+
+### Understanding Change Streams
+
+```bash
+# Just MongoDB needed
+cargo run -p rigatoni-core --example change_stream_listener
+```
+
+---
+
+## Example Matrix
+
+| Example | MongoDB | Redis | S3 | Metrics | Difficulty | Time to Run |
+|---------|---------|-------|----|---------| ----------|-------------|
+| simple_pipeline_memory | ✅ | ❌ | ❌ | ❌ | ⭐ | < 5 min |
+| change_stream_listener | ✅ | ❌ | ❌ | ❌ | ⭐⭐ | < 5 min |
+| s3_basic | ❌ | ❌ | ✅ | ❌ | ⭐ | < 5 min |
+| s3_with_compression | ❌ | ❌ | ✅ | ❌ | ⭐⭐ | < 5 min |
+| s3_advanced | ❌ | ❌ | ✅ | ❌ | ⭐⭐⭐ | < 5 min |
+| metrics_prometheus | ✅ | ✅ | ✅ | ✅ | ⭐⭐ | 10-15 min |
+
+---
+
+## Prerequisites by Example
+
+### Minimal (simple_pipeline_memory)
+- Docker
+- Rust 1.85+
+
+### Standard (most examples)
+- Docker
+- Rust 1.85+
+- AWS credentials (or LocalStack)
+
+### Full Stack (metrics_prometheus)
+- Docker & Docker Compose
+- Rust 1.85+
+- awslocal (optional but recommended)
+
+---
+
+## Common Issues
+
+### MongoDB Not in Replica Set Mode
+
+Many examples require MongoDB to be in replica set mode for change streams:
+
+```bash
+# Start MongoDB with replica set
+docker run -d --name mongodb -p 27017:27017 mongo:7.0 --replSet rs0
+
+# Initialize replica set
+docker exec mongodb mongosh --eval "rs.initiate()"
+```
+
+### LocalStack S3 Bucket Not Found
+
+Create buckets before running S3 examples:
+
+```bash
+awslocal s3 mb s3://rigatoni-test-bucket
+```
+
+### Redis Connection Failed
+
+Make sure Redis is running:
+
+```bash
+docker compose -f docker/docker-compose.yml up -d redis
+```
+
+---
+
+## Learning Path
+
+**Recommended progression for learning Rigatoni:**
+
+1. **Start Simple** → `simple_pipeline_memory.rs`
+   - Get comfortable with basic pipeline concepts
+   - See real-time change stream events
+   - No infrastructure complexity
+
+2. **Add S3** → `s3_basic.rs`
+   - Learn destination patterns
+   - Understand serialization
+   - See data persistence
+
+3. **Add Compression** → `s3_with_compression.rs`
+   - Optimize storage
+   - Compare compression algorithms
+   - Production considerations
+
+4. **Full Observability** → `metrics_prometheus.rs`
+   - Production monitoring
+   - Grafana dashboards
+   - Distributed state with Redis
+
+5. **Advanced Features** → `s3_advanced.rs` & `change_stream_listener.rs`
+   - Custom partitioning
+   - Low-level control
+   - Performance optimization
+
+---
+
+## Contributing Examples
+
+When adding new examples:
+
+1. **Place in appropriate crate** - Keep examples with the features they demonstrate
+2. **Include comprehensive documentation** - Explain what, why, and when
+3. **Minimize dependencies** - Only require what's necessary
+4. **Add error handling** - Show proper error handling patterns
+5. **Update this README** - Add entry with metadata
+6. **Test thoroughly** - Ensure example works from clean state
+
+---
+
+## Additional Resources
+
+- **[Documentation](https://valeriouberti.github.io/rigatoni/)** - Full documentation site
+- **[API Reference](https://docs.rs/rigatoni)** - Complete API documentation
+- **[Architecture Guide](../docs/architecture.md)** - System design and concepts
+- **[Getting Started](../docs/getting-started.md)** - Step-by-step tutorial
+- **[Local Development](../docs/guides/local-development.md)** - Complete local setup guide
+
+---
+
+## Need Help?
+
+- **Issues:** [GitHub Issues](https://github.com/valeriouberti/rigatoni/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/valeriouberti/rigatoni/discussions)
+- **Documentation:** [guides/](../docs/guides/)
+
+---
+
+## Quick Reference Commands
+
+```bash
+# List all examples
+cargo run --example
+
+# Run specific example
+cargo run -p <crate-name> --example <example-name>
+
+# With features
+cargo run -p <crate-name> --example <example-name> --features <features>
+
+# See example help
+cargo run -p <crate-name> --example <example-name> -- --help
+```

--- a/rigatoni-core/Cargo.toml
+++ b/rigatoni-core/Cargo.toml
@@ -62,7 +62,7 @@ tokio-test = { workspace = true }
 
 # For examples - need destinations and stores
 rigatoni-destinations = { path = "../rigatoni-destinations", features = ["s3", "gzip", "json"] }
-rigatoni-stores = { path = "../rigatoni-stores", features = ["redis-store"] }
+rigatoni-stores = { path = "../rigatoni-stores", features = ["memory", "redis-store"] }
 
 [features]
 default = ["mongodb-source"]

--- a/rigatoni-core/examples/README.md
+++ b/rigatoni-core/examples/README.md
@@ -1,0 +1,842 @@
+# Rigatoni Core Examples
+
+This directory contains examples demonstrating the core functionality of Rigatoni, including pipeline orchestration, change stream integration, and observability.
+
+## Quick Reference
+
+| Example | Difficulty | Setup Time | Dependencies | Best For |
+|---------|-----------|------------|--------------|----------|
+| [simple_pipeline_memory.rs](#simple_pipeline_memoryrs) | ⭐ Beginner | < 5 min | MongoDB only | First-time users, quick experiments |
+| [metrics_prometheus.rs](#metrics_prometheusrs) | ⭐⭐ Intermediate | 10-15 min | Full stack | Production preparation, observability |
+| [change_stream_listener.rs](#change_stream_listenerrs) | ⭐⭐ Intermediate | < 5 min | MongoDB only | Understanding internals, custom integrations |
+
+---
+
+## simple_pipeline_memory.rs
+
+**The simplest possible Rigatoni setup** - Perfect starting point for learning the framework.
+
+### What It Does
+
+This example demonstrates:
+- Creating a pipeline with in-memory state store (no Redis required)
+- Watching MongoDB change streams for real-time events
+- Processing events with a simple console destination
+- Graceful shutdown handling
+
+### Prerequisites
+
+**Minimal setup** - Just MongoDB in replica set mode:
+
+```bash
+# Start MongoDB
+docker run -d --name mongodb -p 27017:27017 \
+  mongo:7.0 --replSet rs0
+
+# Initialize replica set (required for change streams)
+docker exec mongodb mongosh --eval "rs.initiate()"
+```
+
+### Running the Example
+
+```bash
+cargo run --example simple_pipeline_memory
+```
+
+The pipeline will start and display:
+```
+🚀 Starting Rigatoni with In-Memory State Store
+✅ In-memory state store created (no external dependencies)
+✅ Console destination created
+📊 Configuration:
+   MongoDB: mongodb://localhost:27017/?replicaSet=rs0&directConnection=true
+   Database: testdb
+   Collections: ["users"]
+   Batch size: 10
+   Batch timeout: 5s
+   State store: In-memory (ephemeral)
+▶️  Starting pipeline...
+✅ Pipeline running!
+```
+
+### Generating Test Data
+
+In another terminal, insert some data to see events:
+
+```bash
+docker exec mongodb mongosh testdb --eval '
+  db.users.insertOne({
+    name: "Alice",
+    email: "alice@example.com",
+    age: 30
+  })
+'
+```
+
+You'll see output like:
+```
+📦 Event received count=1 collection=users operation=Insert
+   Document { _id: ObjectId("..."), name: "Alice", email: "alice@example.com", age: 30 }
+```
+
+### Key Concepts
+
+#### In-Memory State Store
+
+The example uses `MemoryStore` from `rigatoni-stores`:
+
+```rust
+let store = MemoryStore::new();
+```
+
+**Advantages:**
+- No external dependencies (no Redis)
+- Zero configuration
+- Fast local development
+- Perfect for learning and testing
+
+**Limitations:**
+- Resume tokens not persisted across restarts
+- Single process only (no distributed state)
+- Events replay from beginning on restart
+
+For production, use `RedisStore` instead.
+
+#### Console Destination
+
+A simple destination that prints events to the terminal:
+
+```rust
+#[derive(Debug)]
+struct ConsoleDestination {
+    event_count: usize,
+}
+
+#[async_trait::async_trait]
+impl Destination for ConsoleDestination {
+    async fn write_batch(&mut self, events: &[ChangeEvent]) -> Result<(), DestinationError> {
+        for event in events {
+            // Print event details
+        }
+        Ok(())
+    }
+}
+```
+
+This demonstrates the minimal `Destination` trait implementation.
+
+#### Pipeline Configuration
+
+The pipeline is configured with:
+
+```rust
+let config = PipelineConfig::builder()
+    .mongodb_uri("mongodb://localhost:27017/?replicaSet=rs0&directConnection=true")
+    .database("testdb")
+    .collections(vec!["users".to_string()])
+    .batch_size(10)
+    .batch_timeout(Duration::from_secs(5))
+    .build()?;
+```
+
+**Key parameters:**
+- `mongodb_uri` - Connection string (must be replica set)
+- `database` - Database to watch
+- `collections` - Collections to monitor
+- `batch_size` - Max events per batch
+- `batch_timeout` - Max wait time before flushing batch
+
+### Modifying the Example
+
+#### Watch Multiple Collections
+
+```rust
+.collections(vec![
+    "users".to_string(),
+    "orders".to_string(),
+    "products".to_string(),
+])
+```
+
+#### Change Batch Behavior
+
+```rust
+.batch_size(100)                         // Larger batches
+.batch_timeout(Duration::from_secs(1))   // More frequent flushes
+```
+
+#### Use Different Database
+
+```rust
+.database("production")
+.collections(vec!["events".to_string()])
+```
+
+### Common Issues
+
+#### Error: "The $changeStream stage is only supported on replica sets"
+
+**Solution:** Initialize MongoDB as replica set:
+```bash
+docker exec mongodb mongosh --eval "rs.initiate()"
+```
+
+#### No events showing up
+
+**Checklist:**
+1. Is MongoDB running? `docker ps`
+2. Is it a replica set? `docker exec mongodb mongosh --eval "rs.status()"`
+3. Are you inserting to the correct database/collection? (default: `testdb.users`)
+4. Is the pipeline running? Look for "Pipeline running!" message
+
+#### Pipeline restarts from beginning
+
+This is expected with `MemoryStore`. Resume tokens are not persisted. To fix:
+1. Use `RedisStore` for persistent state
+2. See [metrics_prometheus.rs](#metrics_prometheusrs) example
+
+### Next Steps
+
+After mastering this example:
+1. Try [S3 Basic Example](../../rigatoni-destinations/examples/README.md#s3_basicrs) to learn about destinations
+2. Try [metrics_prometheus.rs](#metrics_prometheusrs) for production-like setup with Redis and observability
+
+---
+
+## metrics_prometheus.rs
+
+**Complete production-like example** with full observability stack.
+
+### What It Does
+
+This example demonstrates:
+- Redis state store for distributed, persistent resume tokens
+- S3 destination (via LocalStack) for data lake storage
+- Prometheus metrics export
+- Grafana dashboards for visualization
+- Production-ready error handling and graceful shutdown
+
+### Prerequisites
+
+**Full local development stack** using Docker Compose:
+
+```bash
+# Start all services
+cd docker
+docker compose up -d
+
+# Verify services are running
+docker compose ps
+```
+
+Services started:
+- MongoDB (replica set on port 27017)
+- Redis (port 6379)
+- LocalStack (S3 on port 4566)
+- Prometheus (port 9090)
+- Grafana (port 3000)
+
+### Running the Example
+
+```bash
+# From repo root
+cargo run --example metrics_prometheus --features metrics-export
+```
+
+Required features:
+- `metrics-export` - Enables Prometheus exporter
+
+### Generating Test Data
+
+Use the provided script:
+
+```bash
+./docker/scripts/generate-test-data.sh
+```
+
+Or manually:
+
+```bash
+docker exec mongodb mongosh testdb --eval '
+  for (let i = 0; i < 100; i++) {
+    db.users.insertOne({
+      name: "User " + i,
+      email: "user" + i + "@example.com",
+      timestamp: new Date()
+    });
+  }
+'
+```
+
+### Accessing Services
+
+**Prometheus** - http://localhost:9090
+- Query metrics: `rigatoni_events_processed_total`
+- View targets: Status > Targets
+
+**Grafana** - http://localhost:3000
+- Default credentials: admin/admin
+- Import dashboard: `docs/grafana-dashboard.json`
+- Pre-configured Prometheus datasource
+
+**LocalStack S3** - AWS CLI:
+```bash
+awslocal s3 ls s3://rigatoni-test-bucket/
+```
+
+**MongoDB** - mongosh:
+```bash
+docker exec -it mongodb mongosh testdb
+```
+
+**Redis** - redis-cli:
+```bash
+docker exec -it redis redis-cli
+KEYS rigatoni:*
+```
+
+### Key Concepts
+
+#### Redis State Store
+
+Persistent, distributed resume token storage:
+
+```rust
+use rigatoni_stores::redis::RedisStore;
+
+let redis_config = RedisConfig::builder()
+    .host("localhost")
+    .port(6379)
+    .key_prefix("rigatoni")
+    .build()?;
+
+let store = RedisStore::new(redis_config).await?;
+```
+
+**Advantages over MemoryStore:**
+- Resume tokens survive process restarts
+- Can be shared across multiple pipeline instances
+- Durable storage with Redis persistence
+
+#### S3 Destination
+
+Write events to S3 (LocalStack):
+
+```rust
+use rigatoni_destinations::s3::{S3Destination, S3Config};
+
+let s3_config = S3Config::builder()
+    .bucket("rigatoni-test-bucket")
+    .endpoint("http://localhost:4566")  // LocalStack
+    .region("us-east-1")
+    .build()?;
+
+let destination = S3Destination::new(s3_config).await?;
+```
+
+Supports:
+- Multiple serialization formats (JSON, Parquet)
+- Compression (Gzip, Zstandard)
+- Partitioning strategies (Hive-style, date-based)
+
+#### Metrics Export
+
+Prometheus metrics exposed on port 9091:
+
+```rust
+use metrics_exporter_prometheus::PrometheusBuilder;
+
+let builder = PrometheusBuilder::new();
+builder
+    .with_http_listener(([0, 0, 0, 0], 9091))
+    .install()?;
+```
+
+Available metrics:
+- `rigatoni_events_processed_total` - Counter of processed events
+- `rigatoni_events_failed_total` - Counter of failed events
+- `rigatoni_batch_size` - Histogram of batch sizes
+- `rigatoni_batch_duration_seconds` - Histogram of batch processing time
+- `rigatoni_destination_write_duration_seconds` - Histogram of destination write latency
+- `rigatoni_active_collections` - Gauge of active collections
+- `rigatoni_pipeline_status` - Gauge of pipeline health (1=running, 0=stopped)
+
+All metrics include labels:
+- `collection` - MongoDB collection name
+- `destination_type` - Type of destination (s3, console, etc.)
+- `error_type` - Type of error (for failure metrics)
+
+### Grafana Dashboard
+
+Import the pre-built dashboard:
+
+1. Open Grafana: http://localhost:3000
+2. Navigate to Dashboards > Import
+3. Upload `docs/grafana-dashboard.json`
+4. Select Prometheus datasource
+
+Dashboard panels:
+- Event throughput (events/sec)
+- Error rate
+- Batch size distribution (p50, p95, p99)
+- Processing latency
+- Destination write latency
+- Active collections
+
+### Modifying the Example
+
+#### Use Real AWS S3
+
+Replace LocalStack endpoint with real AWS:
+
+```rust
+let s3_config = S3Config::builder()
+    .bucket("your-production-bucket")
+    .region("us-west-2")
+    // Remove .endpoint() to use real AWS
+    .build()?;
+```
+
+Ensure AWS credentials are configured:
+```bash
+export AWS_ACCESS_KEY_ID="your-key"
+export AWS_SECRET_ACCESS_KEY="your-secret"
+```
+
+#### Add Compression
+
+```rust
+use rigatoni_destinations::s3::Compression;
+
+let s3_config = S3Config::builder()
+    .bucket("rigatoni-test-bucket")
+    .compression(Compression::Gzip)
+    .build()?;
+```
+
+#### Enable Partitioning
+
+```rust
+use rigatoni_destinations::s3::PartitionStrategy;
+
+let s3_config = S3Config::builder()
+    .bucket("rigatoni-test-bucket")
+    .partition_strategy(PartitionStrategy::DateBased {
+        format: "year=%Y/month=%m/day=%d".to_string(),
+    })
+    .build()?;
+```
+
+### Common Issues
+
+#### Redis connection refused
+
+**Check Redis is running:**
+```bash
+docker compose ps redis
+```
+
+**Restart if needed:**
+```bash
+docker compose restart redis
+```
+
+#### LocalStack S3 bucket not found
+
+**Create bucket:**
+```bash
+awslocal s3 mb s3://rigatoni-test-bucket
+```
+
+**Verify:**
+```bash
+awslocal s3 ls
+```
+
+#### Prometheus not scraping metrics
+
+**Check metrics endpoint is accessible:**
+```bash
+curl http://localhost:9091/metrics
+```
+
+**Check Prometheus targets:**
+- Open http://localhost:9090/targets
+- Verify `rigatoni` target is UP
+
+#### No data in Grafana
+
+**Checklist:**
+1. Is the pipeline running and processing events?
+2. Is Prometheus scraping metrics? (check /targets)
+3. Is Grafana datasource configured? (Settings > Data Sources)
+4. Generate test data: `./docker/scripts/generate-test-data.sh`
+
+### Performance Tuning
+
+#### Increase Batch Size
+
+For higher throughput:
+
+```rust
+.batch_size(1000)
+.batch_timeout(Duration::from_secs(10))
+```
+
+**Trade-offs:**
+- Larger batches = higher throughput
+- Longer timeout = more latency
+- More memory usage
+
+#### Adjust Worker Threads
+
+In Cargo.toml:
+
+```toml
+[profile.release]
+opt-level = 3
+lto = true
+```
+
+Or use `TOKIO_WORKER_THREADS`:
+
+```bash
+TOKIO_WORKER_THREADS=4 cargo run --example metrics_prometheus --release
+```
+
+### Production Checklist
+
+Before deploying to production:
+
+- [ ] Replace LocalStack with real AWS S3
+- [ ] Configure Redis persistence (RDB or AOF)
+- [ ] Set up Redis high availability (Sentinel or Cluster)
+- [ ] Enable compression for S3 destination
+- [ ] Configure appropriate batch size/timeout
+- [ ] Set up Prometheus alerting rules
+- [ ] Configure log aggregation
+- [ ] Test graceful shutdown (SIGTERM handling)
+- [ ] Set resource limits (memory, CPU)
+- [ ] Enable TLS for Redis and MongoDB connections
+
+### Next Steps
+
+After mastering this example:
+1. Review [S3 Advanced Example](../../rigatoni-destinations/examples/README.md#s3_advancedrs) for partitioning strategies
+2. Read [Observability Guide](../../docs/OBSERVABILITY.md) for metric details
+3. Read [Production Deployment Guide](../../docs/guides/production-deployment.md)
+
+---
+
+## change_stream_listener.rs
+
+**Low-level change stream API** for advanced use cases and custom integrations.
+
+### What It Does
+
+This example demonstrates:
+- Direct usage of `ChangeStreamListener` without full pipeline
+- Filtering change events by operation type
+- Manual resume token handling
+- Watching multiple collections
+- Custom event processing logic
+
+### Prerequisites
+
+Just MongoDB in replica set mode:
+
+```bash
+docker run -d --name mongodb -p 27017:27017 \
+  mongo:7.0 --replSet rs0
+
+docker exec mongodb mongosh --eval "rs.initiate()"
+```
+
+### Running the Example
+
+```bash
+cargo run --example change_stream_listener
+```
+
+### What You'll See
+
+The example demonstrates several change stream patterns:
+
+1. **Basic listener** - Watch single collection
+2. **Filtered listener** - Only insert and update operations
+3. **Multi-collection** - Watch multiple collections
+4. **Resume token handling** - Save and resume from specific point
+
+### Key Concepts
+
+#### Direct ChangeStreamListener Usage
+
+Without the full pipeline abstraction:
+
+```rust
+use rigatoni_core::stream::ChangeStreamListener;
+use mongodb::Client;
+
+let client = Client::with_uri_str(&uri).await?;
+let db = client.database("testdb");
+
+let listener = ChangeStreamListener::new(
+    db.clone(),
+    vec!["users".to_string()],
+    None, // No resume token
+).await?;
+```
+
+#### Event Filtering
+
+Filter by operation type:
+
+```rust
+use rigatoni_core::event::OperationType;
+
+while let Some(event) = listener.next().await {
+    match event.operation {
+        OperationType::Insert => {
+            // Handle inserts
+        }
+        OperationType::Update => {
+            // Handle updates
+        }
+        OperationType::Delete => {
+            // Handle deletes
+        }
+        _ => continue, // Ignore other operations
+    }
+}
+```
+
+#### Resume Token Management
+
+Save and restore position in change stream:
+
+```rust
+// Get resume token from event
+if let Some(resume_token) = &event.resume_token {
+    // Save token (to Redis, file, database, etc.)
+    save_resume_token("users", resume_token).await?;
+}
+
+// Later, resume from saved token
+let token = load_resume_token("users").await?;
+let listener = ChangeStreamListener::new(
+    db.clone(),
+    vec!["users".to_string()],
+    token, // Resume from this point
+).await?;
+```
+
+This allows processing to continue from where it left off after restart.
+
+#### Multi-Collection Watching
+
+Watch multiple collections with one listener:
+
+```rust
+let listener = ChangeStreamListener::new(
+    db.clone(),
+    vec![
+        "users".to_string(),
+        "orders".to_string(),
+        "products".to_string(),
+    ],
+    None,
+).await?;
+
+while let Some(event) = listener.next().await {
+    println!("Collection: {}", event.namespace.collection);
+    // Handle event based on collection
+}
+```
+
+### Use Cases
+
+#### Custom Aggregation Pipeline
+
+Add MongoDB aggregation to change stream:
+
+```rust
+use mongodb::bson::doc;
+
+let pipeline = vec![
+    doc! {
+        "$match": {
+            "operationType": { "$in": ["insert", "update"] },
+            "fullDocument.status": "active"
+        }
+    }
+];
+
+// Apply pipeline to change stream
+// (Note: This requires modifying ChangeStreamListener internals)
+```
+
+#### Event Routing
+
+Route events to different destinations based on content:
+
+```rust
+while let Some(event) = listener.next().await {
+    if let Some(doc) = &event.full_document {
+        match doc.get_str("type") {
+            Ok("order") => send_to_orders_queue(event).await?,
+            Ok("user") => send_to_users_queue(event).await?,
+            _ => send_to_default_queue(event).await?,
+        }
+    }
+}
+```
+
+#### Change Stream Analytics
+
+Compute real-time statistics:
+
+```rust
+use std::collections::HashMap;
+
+let mut stats: HashMap<String, u64> = HashMap::new();
+
+while let Some(event) = listener.next().await {
+    let key = format!("{}:{:?}", event.namespace.collection, event.operation);
+    *stats.entry(key).or_insert(0) += 1;
+
+    if stats.values().sum::<u64>() % 1000 == 0 {
+        println!("Stats: {:?}", stats);
+    }
+}
+```
+
+### Modifying the Example
+
+#### Add Full Document Lookup
+
+For update events, fetch the full document:
+
+```rust
+use mongodb::options::ChangeStreamOptions;
+
+let options = ChangeStreamOptions::builder()
+    .full_document(Some(mongodb::options::FullDocumentType::UpdateLookup))
+    .build();
+```
+
+#### Filter by Namespace
+
+Only watch specific collections:
+
+```rust
+let pipeline = vec![
+    doc! {
+        "$match": {
+            "ns.coll": { "$in": ["users", "premium_users"] }
+        }
+    }
+];
+```
+
+### Common Issues
+
+#### Error: "cannot open change stream"
+
+**Possible causes:**
+1. MongoDB not in replica set mode
+2. Insufficient permissions
+3. MongoDB version too old (need 3.6+)
+
+**Solution:**
+```bash
+docker exec mongodb mongosh --eval "rs.status()"
+```
+
+#### Missing full document on updates
+
+Update events don't include full document by default. Enable it:
+
+```rust
+.full_document(Some(FullDocumentType::UpdateLookup))
+```
+
+#### Events missed during downtime
+
+Without resume token, events during downtime are lost. Solution:
+1. Always save resume tokens
+2. Use oplog retention to allow catching up
+3. Consider using the full Pipeline for built-in token management
+
+### When to Use This Example
+
+Use `ChangeStreamListener` directly when:
+- Need custom event filtering beyond what Pipeline provides
+- Building custom integration (not using standard destinations)
+- Need fine-grained control over change stream options
+- Implementing custom aggregation pipelines
+- Building real-time analytics on change events
+
+Use full `Pipeline` when:
+- Standard ETL/CDC use case
+- Want built-in batching and retry logic
+- Need metrics and observability
+- Using standard destinations (S3, BigQuery, Kafka)
+
+### Next Steps
+
+After understanding the low-level API:
+1. Review [Pipeline source code](../src/pipeline.rs) to see how it uses `ChangeStreamListener`
+2. Read [MongoDB Change Streams documentation](https://www.mongodb.com/docs/manual/changeStreams/)
+3. Explore [Architecture Guide](../../docs/architecture.md) for system design
+
+---
+
+## Additional Resources
+
+- [Main Examples README](../../examples/README.md) - Complete examples guide
+- [Destination Examples](../../rigatoni-destinations/examples/README.md) - S3 destination examples
+- [Getting Started Guide](../../docs/getting-started.md) - Step-by-step tutorial
+- [Local Development Guide](../../docs/guides/local-development.md) - Complete local setup
+- [API Documentation](https://docs.rs/rigatoni-core) - API reference
+
+---
+
+## Contributing Examples
+
+When adding new core examples:
+
+1. **Follow naming convention** - `{feature}_{variation}.rs`
+2. **Include documentation** - Comprehensive doc comments at top
+3. **Keep minimal** - Only dependencies absolutely needed
+4. **Add README entry** - Document here with full details
+5. **Test from clean state** - Verify setup instructions work
+6. **Show graceful shutdown** - Always handle SIGTERM/Ctrl+C
+
+Example template:
+
+```rust
+//! Brief description
+//!
+//! # Prerequisites
+//!
+//! ```bash
+//! # Setup commands
+//! ```
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo run --example my_example
+//! ```
+
+use rigatoni_core::pipeline::Pipeline;
+// ... rest of implementation
+```
+
+---
+
+## Need Help?
+
+- **Issues:** [GitHub Issues](https://github.com/valeriouberti/rigatoni/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/valeriouberti/rigatoni/discussions)
+- **Guides:** [Documentation](https://valeriouberti.github.io/rigatoni/)

--- a/rigatoni-core/examples/simple_pipeline_memory.rs
+++ b/rigatoni-core/examples/simple_pipeline_memory.rs
@@ -1,0 +1,199 @@
+//! Simple Pipeline Example with In-Memory State Store
+//!
+//! This example demonstrates the simplest possible Rigatoni setup using
+//! an in-memory state store. Perfect for local development and testing.
+//!
+//! # Prerequisites
+//!
+//! Start MongoDB (replica set required for change streams):
+//! ```bash
+//! docker run -d --name mongodb -p 27017:27017 \
+//!   mongo:7.0 --replSet rs0
+//!
+//! # Initialize replica set
+//! docker exec mongodb mongosh --eval "rs.initiate()"
+//! ```
+//!
+//! # Running the Example
+//!
+//! ```bash
+//! cargo run --example simple_pipeline_memory --features metrics-export
+//! ```
+//!
+//! # Generate Test Data
+//!
+//! In another terminal:
+//! ```bash
+//! docker exec mongodb mongosh testdb --eval '
+//!   db.users.insertOne({name: "Alice", email: "alice@example.com", age: 30})
+//! '
+//! ```
+
+use rigatoni_core::destination::{Destination, DestinationError, DestinationMetadata};
+use rigatoni_core::event::ChangeEvent;
+use rigatoni_core::pipeline::{Pipeline, PipelineConfig};
+use rigatoni_stores::memory::MemoryStore;
+use std::error::Error;
+use std::time::Duration;
+use tokio::signal;
+use tracing::{info, warn};
+use tracing_subscriber::{fmt, EnvFilter};
+
+/// Simple console destination that just prints events
+#[derive(Debug)]
+struct ConsoleDestination {
+    event_count: usize,
+}
+
+impl ConsoleDestination {
+    fn new() -> Self {
+        Self { event_count: 0 }
+    }
+}
+
+#[async_trait::async_trait]
+impl Destination for ConsoleDestination {
+    async fn write_batch(&mut self, events: &[ChangeEvent]) -> Result<(), DestinationError> {
+        for event in events {
+            self.event_count += 1;
+            info!(
+                count = self.event_count,
+                collection = %event.namespace.collection,
+                operation = ?event.operation,
+                "📦 Event received"
+            );
+
+            if let Some(doc) = &event.full_document {
+                info!(document = ?doc, "   Document");
+            }
+        }
+        Ok(())
+    }
+
+    async fn flush(&mut self) -> Result<(), DestinationError> {
+        info!("✅ Batch flushed ({} events total)", self.event_count);
+        Ok(())
+    }
+
+    async fn close(&mut self) -> Result<(), DestinationError> {
+        info!(
+            "👋 Destination closed ({} events processed)",
+            self.event_count
+        );
+        Ok(())
+    }
+
+    fn supports_transactions(&self) -> bool {
+        false
+    }
+
+    fn metadata(&self) -> DestinationMetadata {
+        DestinationMetadata::new("Console", "console")
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    // Initialize logging
+    init_logging();
+
+    info!("🚀 Starting Rigatoni with In-Memory State Store");
+    info!("");
+
+    // Create in-memory state store (no configuration needed!)
+    let store = MemoryStore::new();
+    info!("✅ In-memory state store created (no external dependencies)");
+
+    // Create simple console destination
+    let destination = ConsoleDestination::new();
+    info!("✅ Console destination created");
+
+    // Configure pipeline
+    info!("🔧 Configuring pipeline...");
+    let config = PipelineConfig::builder()
+        .mongodb_uri(std::env::var("MONGODB_URI").unwrap_or_else(|_| {
+            "mongodb://localhost:27017/?replicaSet=rs0&directConnection=true".to_string()
+        }))
+        .database("testdb")
+        .collections(vec!["users".to_string()])
+        .batch_size(10)
+        .batch_timeout(Duration::from_secs(5))
+        .build()?;
+
+    info!("✅ Pipeline configured");
+    info!("");
+    info!("📊 Configuration:");
+    info!("   MongoDB: {}", config.mongodb_uri);
+    info!("   Database: {}", config.database);
+    info!("   Collections: {:?}", config.collections);
+    info!("   Batch size: {}", config.batch_size);
+    info!("   Batch timeout: {:?}", config.batch_timeout);
+    info!("   State store: In-memory (ephemeral)");
+    info!("");
+
+    // Create pipeline
+    info!("🎯 Creating pipeline...");
+    let mut pipeline = Pipeline::new(config, store, destination).await?;
+    info!("✅ Pipeline created successfully");
+    info!("");
+
+    // Display usage information
+    display_usage();
+
+    // Start the pipeline
+    info!("▶️  Starting pipeline...");
+    pipeline.start().await?;
+    info!("✅ Pipeline running!");
+    info!("");
+
+    // Wait for Ctrl+C
+    signal::ctrl_c().await?;
+
+    info!("");
+    info!("🛑 Received shutdown signal, stopping pipeline...");
+    pipeline.stop().await?;
+    info!("✅ Pipeline stopped gracefully");
+
+    info!("👋 Example completed!");
+
+    Ok(())
+}
+
+fn display_usage() {
+    info!("💡 Usage:");
+    info!("");
+    info!("   1. The pipeline is now watching for MongoDB change events");
+    info!("   2. Open another terminal and insert data:");
+    info!("");
+    info!("      docker exec mongodb mongosh testdb --eval '");
+    info!("        db.users.insertOne({{");
+    info!("          name: \"Alice\",");
+    info!("          email: \"alice@example.com\",");
+    info!("          age: 30");
+    info!("        }})");
+    info!("      '");
+    info!("");
+    info!("   3. Watch the events appear in this terminal!");
+    info!("   4. Press Ctrl+C to stop gracefully");
+    info!("");
+    warn!("⚠️  Note: Using in-memory state store");
+    warn!("   - Resume tokens are NOT persisted");
+    warn!("   - Events will be replayed from the beginning on restart");
+    warn!("   - Use RedisStore for production deployments");
+    info!("");
+    info!("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━");
+    info!("");
+}
+
+/// Initialize structured logging
+fn init_logging() {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("info,rigatoni_core=info,rigatoni_stores=info"));
+
+    fmt()
+        .with_env_filter(filter)
+        .with_target(false)
+        .with_thread_ids(false)
+        .with_level(true)
+        .init();
+}

--- a/rigatoni-destinations/examples/README.md
+++ b/rigatoni-destinations/examples/README.md
@@ -1,0 +1,1027 @@
+# Rigatoni Destinations Examples
+
+This directory contains examples demonstrating different destination configurations for Rigatoni, with a focus on S3 data lake patterns.
+
+## Quick Reference
+
+| Example | Difficulty | Setup Time | Key Features | Best For |
+|---------|-----------|------------|--------------|----------|
+| [s3_basic.rs](#s3_basicrs) | ⭐ Beginner | < 5 min | JSON, no compression | First-time S3 users, simple setup |
+| [s3_with_compression.rs](#s3_with_compressionrs) | ⭐⭐ Intermediate | < 5 min | Gzip/Zstd compression | Cost optimization, large volumes |
+| [s3_advanced.rs](#s3_advancedrs) | ⭐⭐⭐ Advanced | < 10 min | Parquet, partitioning, analytics | Production data lakes, analytics |
+
+---
+
+## s3_basic.rs
+
+**The simplest S3 destination setup** - Perfect for getting started with S3 integration.
+
+### What It Does
+
+This example demonstrates:
+- Basic S3 configuration with minimal settings
+- JSON serialization (human-readable format)
+- No compression (fastest for small volumes)
+- Default key generation strategy
+- Writing and flushing batches
+
+### Prerequisites
+
+Choose one of these setups:
+
+#### Option 1: LocalStack (Recommended for Testing)
+
+```bash
+# Start LocalStack
+docker compose -f docker/docker-compose.localstack.yml up -d
+
+# Create test bucket
+awslocal s3 mb s3://rigatoni-test-bucket
+
+# Verify bucket exists
+awslocal s3 ls
+```
+
+Set environment for LocalStack:
+```bash
+export AWS_ENDPOINT_URL=http://localhost:4566
+export AWS_REGION=us-east-1
+export AWS_ACCESS_KEY_ID=test
+export AWS_SECRET_ACCESS_KEY=test
+```
+
+#### Option 2: Real AWS S3
+
+Ensure AWS credentials are configured:
+```bash
+# Via AWS CLI
+aws configure
+
+# Or via environment
+export AWS_ACCESS_KEY_ID="your-key-id"
+export AWS_SECRET_ACCESS_KEY="your-secret-key"
+export AWS_REGION="us-west-2"
+
+# Create bucket (if needed)
+aws s3 mb s3://your-bucket-name
+```
+
+### Running the Example
+
+```bash
+# With LocalStack (default)
+cargo run -p rigatoni-destinations --example s3_basic --features s3,json
+
+# With custom bucket
+S3_BUCKET=my-bucket cargo run -p rigatoni-destinations --example s3_basic --features s3,json
+```
+
+### What You'll See
+
+```
+=== Basic S3 Destination Example ===
+
+Using S3 bucket: rigatoni-test-bucket
+
+Configuration:
+  Bucket: rigatoni-test-bucket
+  Region: us-east-1
+  Prefix: Some("rigatoni/examples/basic")
+  Format: Json
+  Compression: None
+
+Destination Metadata:
+  Name: S3
+  Type: s3
+  Supports Transactions: false
+  Supports Concurrent Writes: true
+
+Creating sample change events...
+
+Writing 4 events to S3...
+Flushing to S3...
+
+✓ Successfully wrote events to S3!
+
+You can now check your S3 bucket for the uploaded files.
+Files will be organized by collection and partitioned by date/hour.
+
+✓ Destination closed successfully!
+```
+
+### Verifying the Output
+
+#### With LocalStack:
+
+```bash
+# List uploaded files
+awslocal s3 ls s3://rigatoni-test-bucket/rigatoni/examples/basic/ --recursive
+
+# Download a file
+awslocal s3 cp s3://rigatoni-test-bucket/rigatoni/examples/basic/... local-file.json
+
+# View contents
+cat local-file.json | jq .
+```
+
+#### With Real AWS:
+
+```bash
+# List uploaded files
+aws s3 ls s3://your-bucket/rigatoni/examples/basic/ --recursive
+
+# Download a file
+aws s3 cp s3://your-bucket/rigatoni/examples/basic/... local-file.json
+
+# View contents
+cat local-file.json | jq .
+```
+
+### File Organization
+
+Files are organized with this default structure:
+
+```
+s3://bucket/prefix/collection/YYYY/MM/DD/HH/batch-{uuid}.json
+```
+
+Example:
+```
+rigatoni-test-bucket/
+└── rigatoni/examples/basic/
+    ├── users/
+    │   └── 2025/01/21/14/
+    │       ├── batch-abc123.json
+    │       └── batch-def456.json
+    └── products/
+        └── 2025/01/21/14/
+            └── batch-xyz789.json
+```
+
+### Key Concepts
+
+#### S3Config Builder
+
+The configuration uses a builder pattern:
+
+```rust
+let config = S3Config::builder()
+    .bucket("rigatoni-test-bucket")  // Required: S3 bucket name
+    .region("us-east-1")              // Required: AWS region
+    .prefix("rigatoni/examples/basic") // Optional: Key prefix
+    .build()?;
+```
+
+Additional options (shown with defaults):
+```rust
+.format(SerializationFormat::Json)     // Default format
+.compression(Compression::None)         // No compression
+.max_retries(3)                        // Retry failed uploads
+.timeout(Duration::from_secs(30))      // Upload timeout
+```
+
+#### Destination Trait
+
+The example shows the `Destination` trait in action:
+
+```rust
+// Write a batch of events
+destination.write_batch(&events).await?;
+
+// Flush buffered data to S3
+destination.flush().await?;
+
+// Clean shutdown
+destination.close().await?;
+```
+
+#### SerializationFormat::Json
+
+JSON format characteristics:
+- **Pros:** Human-readable, widely supported, easy debugging
+- **Cons:** Larger file size, slower parsing than binary formats
+- **Best for:** Development, debugging, small-medium volumes
+
+### Modifying the Example
+
+#### Change Bucket and Region
+
+```rust
+let config = S3Config::builder()
+    .bucket("my-production-bucket")
+    .region("eu-west-1")
+    .prefix("mongodb/cdc")
+    .build()?;
+```
+
+#### Use Different Prefix Structure
+
+```rust
+// No prefix (root of bucket)
+.prefix("")
+
+// Deeper hierarchy
+.prefix("data-lake/raw/mongodb/cdc")
+
+// Include environment
+.prefix(format!("mongodb/{}/cdc", env::var("ENV")?))
+```
+
+#### Add Custom Endpoint (for LocalStack)
+
+```rust
+let config = S3Config::builder()
+    .bucket("rigatoni-test-bucket")
+    .region("us-east-1")
+    .endpoint("http://localhost:4566")  // LocalStack endpoint
+    .build()?;
+```
+
+### Common Issues
+
+#### Error: "Bucket does not exist"
+
+**Solution:**
+```bash
+# LocalStack
+awslocal s3 mb s3://rigatoni-test-bucket
+
+# Real AWS
+aws s3 mb s3://your-bucket-name --region us-east-1
+```
+
+#### Error: "Access Denied"
+
+**Checklist:**
+1. Are AWS credentials configured? `aws configure list`
+2. Does IAM user/role have S3 write permissions?
+3. Is bucket policy allowing writes?
+
+**Minimum IAM policy:**
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucket"
+      ],
+      "Resource": [
+        "arn:aws:s3:::your-bucket-name/*",
+        "arn:aws:s3:::your-bucket-name"
+      ]
+    }
+  ]
+}
+```
+
+#### Error: "Connection refused" (LocalStack)
+
+**Check LocalStack is running:**
+```bash
+docker compose -f docker/docker-compose.localstack.yml ps
+
+# Restart if needed
+docker compose -f docker/docker-compose.localstack.yml restart
+```
+
+#### Files not appearing in S3
+
+**Checklist:**
+1. Did you call `flush()`? Files are buffered until flush
+2. Check the correct bucket and prefix
+3. List with `--recursive` flag to see nested keys
+
+### Production Considerations
+
+Before using in production:
+
+- [ ] **Add compression** - See [s3_with_compression.rs](#s3_with_compressionrs)
+- [ ] **Consider binary format** - Parquet for analytics workloads
+- [ ] **Enable S3 lifecycle policies** - Archive old data to Glacier
+- [ ] **Set up CloudWatch alarms** - Monitor upload failures
+- [ ] **Use VPC endpoints** - Reduce data transfer costs
+- [ ] **Enable versioning** - Protect against accidental deletion
+- [ ] **Configure server-side encryption** - Encrypt data at rest
+
+### Next Steps
+
+After mastering basic S3 usage:
+1. Try [s3_with_compression.rs](#s3_with_compressionrs) to reduce storage costs
+2. Try [s3_advanced.rs](#s3_advancedrs) for production data lake patterns
+
+---
+
+## s3_with_compression.rs
+
+**Optimize storage costs and bandwidth** with compression.
+
+### What It Does
+
+This example demonstrates:
+- Gzip compression (industry standard, wide compatibility)
+- Zstandard compression (better ratio, faster than gzip)
+- Compression trade-offs and benchmarking
+- Storage cost optimization
+
+### Prerequisites
+
+Same as [s3_basic.rs](#prerequisites) - LocalStack or real AWS S3.
+
+### Running the Example
+
+#### With Gzip Compression:
+
+```bash
+cargo run -p rigatoni-destinations --example s3_with_compression \
+  --features s3,json,gzip
+```
+
+#### With Zstandard Compression:
+
+```bash
+cargo run -p rigatoni-destinations --example s3_with_compression \
+  --features s3,json,zstandard
+```
+
+#### Without Compression (for comparison):
+
+```bash
+cargo run -p rigatoni-destinations --example s3_with_compression \
+  --features s3,json
+```
+
+### What You'll See
+
+```
+=== S3 Destination with Compression Example ===
+
+Configuration:
+  Bucket: rigatoni-test-bucket
+  Compression: Zstd
+
+Creating 100 sample events...
+Events created: 100
+
+Writing to S3 with Zstd compression...
+
+✓ Successfully wrote 100 events
+  Time taken: 542ms
+
+Compression benefits:
+  - Reduced storage costs
+  - Lower bandwidth usage
+  - Faster uploads for large batches
+
+📊 Zstd: ~75-85% compression ratio (faster than gzip!)
+
+✓ Example completed!
+```
+
+### Compression Comparison
+
+| Algorithm | Ratio | Speed | CPU Usage | Best For |
+|-----------|-------|-------|-----------|----------|
+| **None** | 0% | Fastest | Minimal | Small volumes, low latency |
+| **Gzip** | 70-80% | Medium | Medium | Industry standard, wide compatibility |
+| **Zstd** | 75-85% | Fast | Low-Medium | Modern systems, best balance |
+
+### Key Concepts
+
+#### Enabling Compression
+
+```rust
+use rigatoni_destinations::s3::Compression;
+
+let config = S3Config::builder()
+    .bucket("my-bucket")
+    .region("us-east-1")
+    .compression(Compression::Gzip)  // or Compression::Zstd
+    .build()?;
+```
+
+Available options:
+```rust
+Compression::None    // No compression (default)
+Compression::Gzip    // Requires "gzip" feature
+Compression::Zstd    // Requires "zstandard" feature
+```
+
+#### Storage Cost Savings
+
+Example savings for 100GB/month of MongoDB change events:
+
+**Without compression:**
+- S3 Standard: $2.30/month
+- Data transfer: $0.90/month
+- **Total: $3.20/month**
+
+**With Gzip (75% reduction):**
+- S3 Standard: $0.58/month
+- Data transfer: $0.23/month
+- **Total: $0.81/month**
+- **Savings: $2.39/month (75%)**
+
+At scale (10TB/month): **Save $239/month!**
+
+#### File Extensions
+
+Compressed files automatically get correct extensions:
+
+```
+# Gzip
+batch-abc123.json.gz
+
+# Zstandard
+batch-def456.json.zst
+```
+
+This enables automatic decompression in most analytics tools.
+
+### Verifying Compression
+
+#### Check File Sizes:
+
+```bash
+# List files with sizes
+awslocal s3 ls s3://rigatoni-test-bucket/rigatoni/examples/compressed/ \
+  --recursive --human-readable
+
+# Compare compressed vs uncompressed
+awslocal s3 ls s3://rigatoni-test-bucket/rigatoni/examples/basic/ \
+  --recursive --human-readable --summarize
+awslocal s3 ls s3://rigatoni-test-bucket/rigatoni/examples/compressed/ \
+  --recursive --human-readable --summarize
+```
+
+#### Decompress and View:
+
+```bash
+# Download compressed file
+awslocal s3 cp s3://bucket/path/batch.json.gz - | gunzip | jq .
+
+# For Zstandard
+awslocal s3 cp s3://bucket/path/batch.json.zst - | zstd -d | jq .
+```
+
+### When to Use Compression
+
+**Use Gzip when:**
+- Analytics tools require gzip (Athena, Redshift Spectrum)
+- Need maximum compatibility
+- Storage cost is primary concern
+
+**Use Zstandard when:**
+- Performance matters (faster compression/decompression)
+- Modern analytics stack (Presto, Spark support zstd)
+- Want best compression ratio with good speed
+
+**Skip compression when:**
+- Very small batches (< 1KB)
+- CPU constrained environment
+- Need absolute minimum latency
+- Already using compressed format (Parquet has internal compression)
+
+### Modifying the Example
+
+#### Combine with Parquet
+
+```rust
+let config = S3Config::builder()
+    .bucket("my-bucket")
+    .format(SerializationFormat::Parquet)
+    .compression(Compression::Zstd)  // Double compression!
+    .build()?;
+```
+
+Note: Parquet has internal compression, so external compression provides limited benefit.
+
+#### Adjust Batch Size for Better Compression
+
+```rust
+// Larger batches compress better
+let config = PipelineConfig::builder()
+    .batch_size(10000)  // Increased from default
+    .batch_timeout(Duration::from_secs(30))
+    .build()?;
+```
+
+Larger batches = better compression ratios due to more repetitive data.
+
+### Common Issues
+
+#### Error: "Unsupported compression"
+
+**Solution:** Enable the required feature flag:
+```bash
+# For Gzip
+cargo run --example s3_with_compression --features gzip
+
+# For Zstandard
+cargo run --example s3_with_compression --features zstandard
+```
+
+#### Analytics tools can't read compressed files
+
+**Most tools auto-detect compression from extension:**
+- AWS Athena: Auto-detects `.gz` and `.zst`
+- Presto/Trino: Auto-detects both
+- Spark: Requires codec configuration for Zstd
+
+**If issues occur, verify file extension is correct:**
+```bash
+awslocal s3 ls s3://bucket/path/ --recursive
+# Should see .json.gz or .json.zst
+```
+
+### Performance Benchmarks
+
+Results from 10,000 events (~50MB uncompressed):
+
+| Format | Size | Upload Time | Ratio | Throughput |
+|--------|------|-------------|-------|------------|
+| JSON (uncompressed) | 50MB | 2.1s | - | 23.8 MB/s |
+| JSON + Gzip | 12MB | 1.8s | 76% | 27.8 MB/s |
+| JSON + Zstd | 10MB | 1.5s | 80% | 33.3 MB/s |
+
+**Key insight:** Compression actually *improves* upload speed due to reduced network I/O!
+
+### Next Steps
+
+After mastering compression:
+1. Try [s3_advanced.rs](#s3_advancedrs) for partitioning and analytics
+2. Read [S3 Configuration Guide](../../docs/guides/s3-configuration.md)
+
+---
+
+## s3_advanced.rs
+
+**Production-ready data lake patterns** with partitioning and multiple formats.
+
+### What It Does
+
+This example demonstrates:
+- Multiple serialization formats (JSON, CSV, Parquet, Avro)
+- Hive-style partitioning for analytics
+- Advanced compression strategies
+- Production-grade retry configuration
+- Data lake best practices
+
+### Prerequisites
+
+Same as previous examples - LocalStack or real AWS S3.
+
+### Running the Example
+
+#### With All Features:
+
+```bash
+cargo run -p rigatoni-destinations --example s3_advanced --all-features
+```
+
+#### With Specific Format:
+
+```bash
+# CSV format
+cargo run -p rigatoni-destinations --example s3_advanced \
+  --features s3,csv,gzip
+
+# Parquet format (recommended for analytics)
+cargo run -p rigatoni-destinations --example s3_advanced \
+  --features s3,parquet,zstandard
+
+# Avro format
+cargo run -p rigatoni-destinations --example s3_advanced \
+  --features s3,avro
+```
+
+### What You'll See
+
+```
+=== Advanced S3 Destination Example ===
+
+Configuration:
+  Bucket: rigatoni-test-bucket
+  Format: Parquet
+  Compression: Zstd
+  Partitioning: Hive-style (for analytics)
+
+📁 Key Generation Strategy:
+  Pattern: collection={collection}/year={year}/month={month}/day={day}/
+
+  Benefits:
+  ✓ Automatic partition discovery in Athena/Presto/Spark
+  ✓ Efficient time-range queries
+  ✓ Organized data lake structure
+
+Creating sample events across collections...
+  Total events: 30
+  Collections: users, orders, products
+
+Writing to S3...
+
+✓ Successfully wrote events!
+  Time taken: 1.2s
+
+📊 Data Organization:
+  Each collection will have separate partitioned files:
+  - analytics/mongodb-cdc/collection=users/year=2025/month=01/day=21/...
+  - analytics/mongodb-cdc/collection=orders/year=2025/month=01/day=21/...
+  - analytics/mongodb-cdc/collection=products/year=2025/month=01/day=21/...
+
+💡 Analytics Usage:
+  You can now query this data using:
+  - AWS Athena: CREATE EXTERNAL TABLE with PARTITIONED BY
+  - Presto/Trino: Automatic partition discovery
+  - Apache Spark: Read with partition pruning
+
+✓ Example completed!
+```
+
+### Key Concepts
+
+#### Hive-Style Partitioning
+
+Partitioning organizes data for efficient analytics queries:
+
+```rust
+use rigatoni_destinations::s3::KeyGenerationStrategy;
+
+let config = S3Config::builder()
+    .bucket("my-bucket")
+    .key_strategy(KeyGenerationStrategy::HivePartitioned)
+    .build()?;
+```
+
+**File structure:**
+```
+s3://bucket/prefix/
+  collection=users/
+    year=2025/
+      month=01/
+        day=21/
+          hour=14/
+            batch-abc123.parquet
+  collection=orders/
+    year=2025/
+      month=01/
+        day=21/
+          hour=14/
+            batch-def456.parquet
+```
+
+**Benefits:**
+- **Partition pruning:** Query only relevant partitions
+- **Auto-discovery:** Athena/Presto automatically detect partitions
+- **Cost savings:** Scan less data = lower costs
+- **Performance:** 10-100x faster queries with proper partitioning
+
+#### SerializationFormat Options
+
+```rust
+use rigatoni_destinations::s3::SerializationFormat;
+
+// JSON - Human-readable, debugging
+.format(SerializationFormat::Json)
+
+// CSV - Simple, widely compatible
+.format(SerializationFormat::Csv)
+
+// Parquet - Columnar, best for analytics (recommended!)
+.format(SerializationFormat::Parquet)
+
+// Avro - Row-based, schema evolution
+.format(SerializationFormat::Avro)
+```
+
+**Format Comparison:**
+
+| Format | Type | Size | Query Speed | Schema | Best For |
+|--------|------|------|-------------|--------|----------|
+| JSON | Row | 1x | Slow | Flexible | Development, debugging |
+| CSV | Row | 0.5x | Slow | Fixed | Simple exports, spreadsheets |
+| Parquet | Columnar | 0.1x | **Very Fast** | Strict | Analytics, data lakes |
+| Avro | Row | 0.3x | Medium | Evolvable | Streaming, schema changes |
+
+**Recommendation:** Use **Parquet** for production data lakes!
+
+#### KeyGenerationStrategy Options
+
+```rust
+// Hive-style partitioning (recommended for analytics)
+.key_strategy(KeyGenerationStrategy::HivePartitioned)
+// Example: collection=users/year=2025/month=01/day=21/batch.parquet
+
+// Date-based partitioning (simpler)
+.key_strategy(KeyGenerationStrategy::DateBased)
+// Example: users/2025/01/21/batch.parquet
+
+// UUID-based (no partitioning)
+.key_strategy(KeyGenerationStrategy::Uuid)
+// Example: users/abc-123-def-456.parquet
+
+// Custom strategy
+.key_strategy(KeyGenerationStrategy::Custom(Box::new(my_fn)))
+```
+
+#### Production Retry Configuration
+
+```rust
+let config = S3Config::builder()
+    .bucket("my-bucket")
+    .max_retries(5)                              // More retries
+    .timeout(Duration::from_secs(60))            // Longer timeout
+    .retry_delay(Duration::from_secs(2))         // Delay between retries
+    .build()?;
+```
+
+### Analytics Integration
+
+#### AWS Athena
+
+Create external table:
+
+```sql
+CREATE EXTERNAL TABLE mongodb_users (
+  _id INT,
+  name STRING,
+  event_type STRING,
+  status STRING,
+  created_at TIMESTAMP,
+  metadata STRUCT<version:STRING, source:STRING, environment:STRING>
+)
+PARTITIONED BY (
+  collection STRING,
+  year INT,
+  month INT,
+  day INT
+)
+STORED AS PARQUET
+LOCATION 's3://rigatoni-test-bucket/analytics/mongodb-cdc/';
+
+-- Discover partitions
+MSCK REPAIR TABLE mongodb_users;
+
+-- Query specific partition (fast!)
+SELECT * FROM mongodb_users
+WHERE collection = 'users'
+  AND year = 2025
+  AND month = 1
+  AND day = 21;
+```
+
+#### Apache Spark
+
+```python
+from pyspark.sql import SparkSession
+
+spark = SparkSession.builder.appName("MongoDB CDC").getOrCreate()
+
+# Read partitioned Parquet
+df = spark.read.parquet("s3://rigatoni-test-bucket/analytics/mongodb-cdc/")
+
+# Automatic partition pruning
+users_today = df.filter(
+    (df.collection == "users") &
+    (df.year == 2025) &
+    (df.month == 1) &
+    (df.day == 21)
+)
+
+users_today.show()
+```
+
+#### Presto/Trino
+
+```sql
+-- Auto-discovers partitions
+SELECT collection, COUNT(*)
+FROM hive.default.mongodb_cdc
+WHERE year = 2025 AND month = 1
+GROUP BY collection;
+```
+
+### Modifying the Example
+
+#### Custom Partitioning Strategy
+
+```rust
+fn custom_key_fn(
+    collection: &str,
+    timestamp: &DateTime<Utc>,
+    batch_id: &str,
+) -> String {
+    format!(
+        "env=production/source=mongodb/collection={}/date={}/hour={}/{}.parquet",
+        collection,
+        timestamp.format("%Y-%m-%d"),
+        timestamp.format("%H"),
+        batch_id
+    )
+}
+
+let config = S3Config::builder()
+    .bucket("my-bucket")
+    .key_strategy(KeyGenerationStrategy::Custom(Box::new(custom_key_fn)))
+    .build()?;
+```
+
+#### Combine Best Practices
+
+```rust
+let config = S3Config::builder()
+    .bucket("production-data-lake")
+    .region("us-west-2")
+    .prefix("raw/mongodb-cdc")
+    .format(SerializationFormat::Parquet)     // Best for analytics
+    .compression(Compression::Zstd)            // Best compression
+    .key_strategy(KeyGenerationStrategy::HivePartitioned)  // Best partitioning
+    .max_retries(5)                            // Production retries
+    .timeout(Duration::from_secs(120))         // Longer timeout
+    .build()?;
+```
+
+### Common Issues
+
+#### Athena: "HIVE_PARTITION_SCHEMA_MISMATCH"
+
+**Cause:** Partition column types don't match table definition
+
+**Solution:** Ensure partition columns are defined correctly:
+```sql
+PARTITIONED BY (
+  collection STRING,  -- Not INT!
+  year INT,           -- Not STRING!
+  month INT,
+  day INT
+)
+```
+
+#### Spark: "Partition discovery too slow"
+
+**Solution:** Explicitly specify partition schema:
+```python
+df = spark.read \
+    .option("basePath", "s3://bucket/prefix/") \
+    .parquet("s3://bucket/prefix/collection=users/")
+```
+
+#### Parquet files too small
+
+**Cause:** Small batch sizes create many tiny files
+
+**Solution:** Increase batch size:
+```rust
+let config = PipelineConfig::builder()
+    .batch_size(10000)  // Larger batches = larger Parquet files
+    .build()?;
+```
+
+**Ideal Parquet file size:** 128MB - 1GB per file
+
+### Production Checklist
+
+Before deploying to production data lake:
+
+- [ ] **Use Parquet format** - Best performance and compression
+- [ ] **Enable Hive partitioning** - Required for efficient queries
+- [ ] **Set appropriate batch size** - 10,000+ events for optimal file sizes
+- [ ] **Enable compression** - Zstd for Parquet
+- [ ] **Configure S3 lifecycle** - Archive old partitions to Glacier
+- [ ] **Set up AWS Glue Crawler** - Auto-discover partitions
+- [ ] **Create Athena views** - Simplify queries for analysts
+- [ ] **Monitor upload failures** - CloudWatch alarms
+- [ ] **Test partition pruning** - Verify queries are efficient
+- [ ] **Document schema** - Maintain schema registry
+
+### Performance Tuning
+
+#### Optimize for Query Performance
+
+```rust
+// Large batch size = larger Parquet files = better analytics performance
+.batch_size(50000)
+.batch_timeout(Duration::from_secs(300))  // 5 minutes
+```
+
+#### Optimize for Write Throughput
+
+```rust
+// Smaller batches = lower latency, more frequent writes
+.batch_size(1000)
+.batch_timeout(Duration::from_secs(10))
+```
+
+#### Balance Both
+
+```rust
+// Medium batch size for balanced performance
+.batch_size(10000)
+.batch_timeout(Duration::from_secs(60))
+```
+
+### Cost Optimization
+
+**Strategies to reduce costs:**
+
+1. **Compression:** Zstd reduces storage by 75-85%
+2. **Partitioning:** Query only necessary partitions
+3. **Lifecycle policies:** Archive old data to Glacier
+4. **VPC endpoints:** Eliminate data transfer costs
+5. **Intelligent tiering:** Auto-move infrequent data
+
+**Example savings for 1TB/month:**
+- Without optimization: $23/month
+- With Parquet + Zstd + lifecycle: $2/month
+- **Savings: 91%!**
+
+### Next Steps
+
+After mastering advanced S3 patterns:
+1. Read [S3 Configuration Guide](../../docs/guides/s3-configuration.md)
+2. Review [Production Deployment Guide](../../docs/guides/production-deployment.md)
+3. Explore [Metrics Example](../../rigatoni-core/examples/README.md#metrics_prometheusrs)
+
+---
+
+## Additional Resources
+
+- [Main Examples README](../../examples/README.md) - Complete examples guide
+- [Core Examples](../../rigatoni-core/examples/README.md) - Pipeline and metrics examples
+- [S3 Configuration Guide](../../docs/guides/s3-configuration.md) - Detailed S3 setup
+- [Architecture Guide](../../docs/architecture.md) - System design
+- [API Documentation](https://docs.rs/rigatoni-destinations) - API reference
+
+---
+
+## Feature Flags Reference
+
+When running examples, you'll need these feature flags:
+
+| Feature | Description | Required For |
+|---------|-------------|--------------|
+| `s3` | S3 destination | All S3 examples |
+| `json` | JSON serialization | JSON format |
+| `csv` | CSV serialization | CSV format |
+| `parquet` | Parquet serialization | Parquet format (analytics) |
+| `avro` | Avro serialization | Avro format |
+| `gzip` | Gzip compression | Compressed uploads |
+| `zstandard` | Zstandard compression | Better compression |
+
+**Common combinations:**
+
+```bash
+# Development
+--features s3,json
+
+# Production data lake
+--features s3,parquet,zstandard
+
+# All features
+--all-features
+```
+
+---
+
+## Environment Variables
+
+Examples support these environment variables:
+
+```bash
+# S3 bucket name (defaults to rigatoni-test-bucket)
+export S3_BUCKET="your-bucket-name"
+
+# AWS region (defaults to us-east-1)
+export AWS_REGION="us-west-2"
+
+# LocalStack endpoint (for local testing)
+export AWS_ENDPOINT_URL="http://localhost:4566"
+
+# AWS credentials
+export AWS_ACCESS_KEY_ID="your-key"
+export AWS_SECRET_ACCESS_KEY="your-secret"
+```
+
+---
+
+## Contributing Examples
+
+When adding new destination examples:
+
+1. **Follow naming convention** - `{destination}_{feature}.rs`
+2. **Include comprehensive docs** - Prerequisites, features, use cases
+3. **Support both LocalStack and real AWS** - Test locally first
+4. **Show best practices** - Production-ready configurations
+5. **Add to this README** - Document thoroughly
+6. **Test from clean state** - Verify setup instructions work
+
+---
+
+## Need Help?
+
+- **Issues:** [GitHub Issues](https://github.com/valeriouberti/rigatoni/issues)
+- **Discussions:** [GitHub Discussions](https://github.com/valeriouberti/rigatoni/discussions)
+- **Guides:** [Documentation](https://valeriouberti.github.io/rigatoni/)

--- a/rigatoni-stores/src/lib.rs
+++ b/rigatoni-stores/src/lib.rs
@@ -22,13 +22,38 @@
 //!
 //! # Available Stores
 //!
+//! - **Memory** (`memory` feature, enabled by default): In-memory state storage
 //! - **Redis** (`redis-store` feature): Distributed state storage with Redis
+//! - **File** (`file` feature, coming soon): File-based state storage
 //!
 //! # Feature Flags
 //!
-//! - `redis-store`: Enables Redis-backed state store (requires Redis server)
-//! - `memory`: In-memory state store (coming soon)
+//! - `memory`: In-memory state store (enabled by default)
+//! - `redis-store`: Redis-backed state store (requires Redis server)
 //! - `file`: File-based state store (coming soon)
+//! - `all-stores`: Enable all available stores
+//!
+//! # Example: In-Memory Store
+//!
+//! ```rust
+//! use rigatoni_stores::memory::MemoryStore;
+//! use rigatoni_core::state::StateStore;
+//! use mongodb::bson::doc;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create in-memory store (no configuration needed)
+//! let store = MemoryStore::new();
+//!
+//! // Save resume token
+//! let token = doc! { "_data": "token123" };
+//! store.save_resume_token("users", &token).await?;
+//!
+//! // Retrieve token
+//! let retrieved = store.get_resume_token("users").await?;
+//! assert!(retrieved.is_some());
+//! # Ok(())
+//! # }
+//! ```
 //!
 //! # Example: Redis Store
 //!
@@ -61,6 +86,9 @@
 #![warn(missing_docs)]
 #![warn(clippy::all)]
 #![warn(clippy::pedantic)]
+
+#[cfg(feature = "memory")]
+pub mod memory;
 
 #[cfg(feature = "redis-store")]
 pub mod redis;

--- a/rigatoni-stores/src/memory.rs
+++ b/rigatoni-stores/src/memory.rs
@@ -1,0 +1,562 @@
+// Copyright 2025 Rigatoni Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-memory state store implementation.
+//!
+//! This module provides a thread-safe, in-memory implementation of the
+//! [`StateStore`] trait for storing `MongoDB`
+//! change stream resume tokens.
+//!
+//! # Use Cases
+//!
+//! The in-memory store is suitable for:
+//!
+//! - **Local development and testing** - No external dependencies required
+//! - **Single-instance deployments** - Where distributed state isn't needed
+//! - **Prototyping** - Quick setup without infrastructure
+//!
+//! # Limitations
+//!
+//! ⚠️ **Important**: The in-memory store has the following limitations:
+//!
+//! - **No persistence** - Tokens are lost on process restart
+//! - **Single process only** - Cannot be shared across multiple instances
+//! - **No durability** - Data lost on crash or shutdown
+//!
+//! For production deployments with multiple instances or high availability
+//! requirements, use [`RedisStore`](crate::redis::RedisStore) instead.
+//!
+//! # Example
+//!
+//! ```rust
+//! use rigatoni_stores::memory::MemoryStore;
+//! use rigatoni_core::state::StateStore;
+//! use mongodb::bson::doc;
+//!
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! // Create in-memory store
+//! let store = MemoryStore::new();
+//!
+//! // Save resume token
+//! let token = doc! { "_data": "token_abc123" };
+//! store.save_resume_token("users", &token).await?;
+//!
+//! // Retrieve token
+//! let retrieved = store.get_resume_token("users").await?;
+//! assert!(retrieved.is_some());
+//!
+//! // List all tokens
+//! let all_tokens = store.list_resume_tokens().await?;
+//! assert_eq!(all_tokens.len(), 1);
+//!
+//! // Delete token
+//! store.delete_resume_token("users").await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Thread Safety
+//!
+//! The store uses [`Arc`] and [`RwLock`] internally, making it safe to share
+//! across async tasks and threads.
+//!
+//! ```rust
+//! use rigatoni_stores::memory::MemoryStore;
+//! use std::sync::Arc;
+//!
+//! # async fn example() {
+//! let store = Arc::new(MemoryStore::new());
+//!
+//! // Clone and use in multiple tasks
+//! let store_clone = Arc::clone(&store);
+//! tokio::spawn(async move {
+//!     // Use store_clone in async task
+//! });
+//! # }
+//! ```
+
+use bson::Document;
+use rigatoni_core::state::{StateStore, StateStoreError};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, trace, warn};
+
+/// In-memory state store for `MongoDB` change stream resume tokens.
+///
+/// This store keeps all resume tokens in memory using a thread-safe
+/// [`HashMap`] protected by an [`RwLock`].
+///
+/// # Performance
+///
+/// - **Read operations** - Fast, multiple readers can access concurrently
+/// - **Write operations** - Slightly slower due to exclusive lock
+/// - **Memory usage** - Proportional to number of collections tracked
+///
+/// # Example
+///
+/// ```rust
+/// use rigatoni_stores::memory::MemoryStore;
+/// use rigatoni_core::pipeline::{Pipeline, PipelineConfig};
+/// use std::time::Duration;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// // Create store
+/// let store = MemoryStore::new();
+///
+/// // Use with pipeline
+/// let config = PipelineConfig::builder()
+///     .mongodb_uri("mongodb://localhost:27017")
+///     .database("mydb")
+///     .collections(vec!["users".to_string()])
+///     .build()?;
+///
+/// // let destination = /* your destination */;
+/// // let pipeline = Pipeline::new(config, store, destination).await?;
+/// # Ok(())
+/// # }
+/// ```
+#[derive(Debug, Clone)]
+pub struct MemoryStore {
+    /// Internal storage for resume tokens
+    tokens: Arc<RwLock<HashMap<String, Document>>>,
+}
+
+impl MemoryStore {
+    /// Creates a new in-memory state store.
+    ///
+    /// The store is initially empty.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rigatoni_stores::memory::MemoryStore;
+    ///
+    /// let store = MemoryStore::new();
+    /// ```
+    #[must_use]
+    pub fn new() -> Self {
+        debug!("Creating new in-memory state store");
+        Self {
+            tokens: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Creates a new in-memory store with pre-populated tokens.
+    ///
+    /// This is useful for testing or when migrating from another store.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rigatoni_stores::memory::MemoryStore;
+    /// use mongodb::bson::doc;
+    /// use std::collections::HashMap;
+    ///
+    /// let mut initial_tokens = HashMap::new();
+    /// initial_tokens.insert("users".to_string(), doc! { "_data": "token123" });
+    ///
+    /// let store = MemoryStore::with_tokens(initial_tokens);
+    /// ```
+    #[must_use]
+    pub fn with_tokens(tokens: HashMap<String, Document>) -> Self {
+        debug!(
+            token_count = tokens.len(),
+            "Creating in-memory state store with initial tokens"
+        );
+        Self {
+            tokens: Arc::new(RwLock::new(tokens)),
+        }
+    }
+
+    /// Returns the current number of stored tokens.
+    ///
+    /// This is useful for monitoring and debugging.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rigatoni_stores::memory::MemoryStore;
+    /// # use rigatoni_core::state::StateStore;
+    /// # use mongodb::bson::doc;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let store = MemoryStore::new();
+    ///
+    /// assert_eq!(store.len().await, 0);
+    ///
+    /// store.save_resume_token("users", &doc! { "_data": "token" }).await?;
+    /// assert_eq!(store.len().await, 1);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn len(&self) -> usize {
+        self.tokens.read().await.len()
+    }
+
+    /// Returns `true` if the store contains no tokens.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rigatoni_stores::memory::MemoryStore;
+    /// # async fn example() {
+    /// let store = MemoryStore::new();
+    /// assert!(store.is_empty().await);
+    /// # }
+    /// ```
+    pub async fn is_empty(&self) -> bool {
+        self.tokens.read().await.is_empty()
+    }
+
+    /// Clears all stored tokens.
+    ///
+    /// This removes all resume tokens from the store.
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// # use rigatoni_stores::memory::MemoryStore;
+    /// # use rigatoni_core::state::StateStore;
+    /// # use mongodb::bson::doc;
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let store = MemoryStore::new();
+    /// store.save_resume_token("users", &doc! { "_data": "token" }).await?;
+    ///
+    /// store.clear().await;
+    /// assert!(store.is_empty().await);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn clear(&self) {
+        let mut tokens = self.tokens.write().await;
+        let count = tokens.len();
+        tokens.clear();
+        debug!(
+            cleared_count = count,
+            "Cleared all tokens from memory store"
+        );
+    }
+}
+
+impl Default for MemoryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait::async_trait]
+impl StateStore for MemoryStore {
+    async fn save_resume_token(
+        &self,
+        collection: &str,
+        token: &Document,
+    ) -> Result<(), StateStoreError> {
+        trace!(
+            collection = collection,
+            token = ?token,
+            "Saving resume token to memory"
+        );
+
+        let mut tokens = self.tokens.write().await;
+        tokens.insert(collection.to_string(), token.clone());
+
+        debug!(
+            collection = collection,
+            total_tokens = tokens.len(),
+            "Saved resume token to memory"
+        );
+
+        Ok(())
+    }
+
+    async fn get_resume_token(
+        &self,
+        collection: &str,
+    ) -> Result<Option<Document>, StateStoreError> {
+        trace!(
+            collection = collection,
+            "Retrieving resume token from memory"
+        );
+
+        let tokens = self.tokens.read().await;
+        let token = tokens.get(collection).cloned();
+
+        if token.is_some() {
+            debug!(collection = collection, "Found resume token in memory");
+        } else {
+            debug!(collection = collection, "No resume token found in memory");
+        }
+
+        Ok(token)
+    }
+
+    async fn delete_resume_token(&self, collection: &str) -> Result<(), StateStoreError> {
+        trace!(collection = collection, "Deleting resume token from memory");
+
+        let mut tokens = self.tokens.write().await;
+        let removed = tokens.remove(collection);
+
+        if removed.is_some() {
+            debug!(
+                collection = collection,
+                remaining_tokens = tokens.len(),
+                "Deleted resume token from memory"
+            );
+        } else {
+            warn!(
+                collection = collection,
+                "Attempted to delete non-existent resume token"
+            );
+        }
+
+        Ok(())
+    }
+
+    async fn list_resume_tokens(&self) -> Result<HashMap<String, Document>, StateStoreError> {
+        trace!("Listing all resume tokens from memory");
+
+        let tokens = self.tokens.read().await;
+        let token_count = tokens.len();
+
+        debug!(
+            token_count = token_count,
+            "Listed all resume tokens from memory"
+        );
+
+        Ok(tokens.clone())
+    }
+
+    async fn close(&self) -> Result<(), StateStoreError> {
+        debug!("Closing in-memory state store (no-op)");
+        // No resources to clean up for in-memory store
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bson::doc;
+
+    #[tokio::test]
+    async fn test_new_store_is_empty() {
+        let store = MemoryStore::new();
+        assert!(store.is_empty().await);
+        assert_eq!(store.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_save_and_retrieve_token() {
+        let store = MemoryStore::new();
+        let token = doc! { "_data": "test_token_123" };
+
+        // Save token
+        store
+            .save_resume_token("users", &token)
+            .await
+            .expect("Failed to save token");
+
+        // Retrieve token
+        let retrieved = store
+            .get_resume_token("users")
+            .await
+            .expect("Failed to retrieve token");
+
+        assert!(retrieved.is_some());
+        assert_eq!(retrieved.unwrap(), token);
+        assert_eq!(store.len().await, 1);
+    }
+
+    #[tokio::test]
+    async fn test_retrieve_nonexistent_token() {
+        let store = MemoryStore::new();
+
+        let retrieved = store
+            .get_resume_token("nonexistent")
+            .await
+            .expect("Failed to retrieve token");
+
+        assert!(retrieved.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_token() {
+        let store = MemoryStore::new();
+        let token1 = doc! { "_data": "token_v1" };
+        let token2 = doc! { "_data": "token_v2" };
+
+        // Save initial token
+        store
+            .save_resume_token("users", &token1)
+            .await
+            .expect("Failed to save token");
+
+        // Update with new token
+        store
+            .save_resume_token("users", &token2)
+            .await
+            .expect("Failed to update token");
+
+        // Verify updated
+        let retrieved = store.get_resume_token("users").await.unwrap();
+        assert_eq!(retrieved.unwrap(), token2);
+        assert_eq!(store.len().await, 1); // Still only one token
+    }
+
+    #[tokio::test]
+    async fn test_delete_token() {
+        let store = MemoryStore::new();
+        let token = doc! { "_data": "test_token" };
+
+        // Save and then delete
+        store.save_resume_token("users", &token).await.unwrap();
+        assert_eq!(store.len().await, 1);
+
+        store.delete_resume_token("users").await.unwrap();
+        assert_eq!(store.len().await, 0);
+
+        // Verify deleted
+        let retrieved = store.get_resume_token("users").await.unwrap();
+        assert!(retrieved.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent_token() {
+        let store = MemoryStore::new();
+
+        // Should not error when deleting nonexistent token
+        store.delete_resume_token("nonexistent").await.unwrap();
+        assert_eq!(store.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_list_tokens() {
+        let store = MemoryStore::new();
+        let token1 = doc! { "_data": "token1" };
+        let token2 = doc! { "_data": "token2" };
+        let token3 = doc! { "_data": "token3" };
+
+        // Save multiple tokens
+        store.save_resume_token("users", &token1).await.unwrap();
+        store.save_resume_token("orders", &token2).await.unwrap();
+        store.save_resume_token("products", &token3).await.unwrap();
+
+        // List all
+        let all_tokens = store.list_resume_tokens().await.unwrap();
+        assert_eq!(all_tokens.len(), 3);
+        assert_eq!(all_tokens.get("users"), Some(&token1));
+        assert_eq!(all_tokens.get("orders"), Some(&token2));
+        assert_eq!(all_tokens.get("products"), Some(&token3));
+    }
+
+    #[tokio::test]
+    async fn test_list_empty_store() {
+        let store = MemoryStore::new();
+        let tokens = store.list_resume_tokens().await.unwrap();
+        assert!(tokens.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_clear() {
+        let store = MemoryStore::new();
+
+        // Add some tokens
+        store
+            .save_resume_token("users", &doc! { "_data": "token1" })
+            .await
+            .unwrap();
+        store
+            .save_resume_token("orders", &doc! { "_data": "token2" })
+            .await
+            .unwrap();
+        assert_eq!(store.len().await, 2);
+
+        // Clear
+        store.clear().await;
+        assert!(store.is_empty().await);
+        assert_eq!(store.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn test_with_tokens() {
+        let mut initial = HashMap::new();
+        initial.insert("users".to_string(), doc! { "_data": "token1" });
+        initial.insert("orders".to_string(), doc! { "_data": "token2" });
+
+        let store = MemoryStore::with_tokens(initial);
+        assert_eq!(store.len().await, 2);
+
+        let token = store.get_resume_token("users").await.unwrap();
+        assert!(token.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_close() {
+        let store = MemoryStore::new();
+        // Close should succeed
+        store.close().await.expect("Failed to close store");
+    }
+
+    #[tokio::test]
+    async fn test_concurrent_access() {
+        use std::sync::Arc;
+
+        let store = Arc::new(MemoryStore::new());
+        let mut handles = vec![];
+
+        // Spawn multiple tasks writing to different collections
+        for i in 0..10 {
+            let store_clone = Arc::clone(&store);
+            let handle = tokio::spawn(async move {
+                let collection = format!("collection_{i}");
+                let token = doc! { "_data": format!("token_{i}") };
+                store_clone
+                    .save_resume_token(&collection, &token)
+                    .await
+                    .unwrap();
+            });
+            handles.push(handle);
+        }
+
+        // Wait for all tasks
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // Verify all tokens saved
+        assert_eq!(store.len().await, 10);
+    }
+
+    #[tokio::test]
+    async fn test_clone() {
+        let store1 = MemoryStore::new();
+        store1
+            .save_resume_token("users", &doc! { "_data": "token" })
+            .await
+            .unwrap();
+
+        // Clone shares the same underlying storage
+        let store2 = store1.clone();
+        assert_eq!(store2.len().await, 1);
+
+        // Changes in store2 are visible in store1
+        store2
+            .save_resume_token("orders", &doc! { "_data": "token2" })
+            .await
+            .unwrap();
+        assert_eq!(store1.len().await, 2);
+    }
+}


### PR DESCRIPTION
- Introduced `MemoryStore` for in-memory storage of MongoDB change stream resume tokens.
- Implemented thread-safe access using `Arc` and `RwLock`.
- Added methods for saving, retrieving, deleting, and listing tokens.
- Included examples and documentation for usage.
- Updated `lib.rs` to expose the new memory store module.